### PR TITLE
Load cl-lib.el instead of cl.el

### DIFF
--- a/malinka.el
+++ b/malinka.el
@@ -47,9 +47,7 @@
 
 ;;; Code:
 
-(eval-when-compile
-(require 'cl))
-
+(require 'cl-lib)
 (require 'projectile)
 (require 's)
 (require 'dash)


### PR DESCRIPTION
Because it is declared as package dependency and this package uses cl-lib functions,
not cl.el.